### PR TITLE
Add GH workflow for releasing signed binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,7 @@ jobs:
       uses: crazy-max/ghaction-import-gpg@v5
       with:
         gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-        passphrase: ${{ secrets.PASSPHRASE }}
-        fingerprint: "C17D11ADF199F12A30A0910F1F80449BE0B08CB8"
+        passphrase: ${{ secrets.GPG_PASSPHRASE }}
 
     - name: List Keys
       run: gpg -K

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         body: "# CHANGELOG"
         draft: true
         files: |
-          deucalion.dll
-          deucalion.sha256sum
-          deucalion.sha256sum.asc
+          deucalion/deucalion.dll
+          deucalion/deucalion.sha256sum
+          deucalion/deucalion.sha256sum.asc
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         body: "# CHANGELOG"
         draft: true
         files: |
-          deucalion/deucalion.dll
+          deucalion/target/release/deucalion.dll
           deucalion/deucalion.sha256sum
           deucalion/deucalion.sha256sum.asc
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Build
+on:
+  push:
+    branches: [ signing_test ]
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install latest nightly
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        components: rustfmt, clippy
+
+    - name: Import GPG key
+      id: import_gpg
+      uses: crazy-max/ghaction-import-gpg@v5
+      with:
+        gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+        passphrase: ${{ secrets.PASSPHRASE }}
+        fingerprint: "C17D11ADF199F12A30A0910F1F80449BE0B08CB8"
+
+    - name: List Keys
+      run: gpg -K
+
+    - name: Build
+      run: |
+        cargo build --release
+        sha256sum target/release/deucalion.dll > deucalion.sha256sum
+        gpg --output deucalion.sha256sum.asc --clearsign deucalion.sha256sum
+        cat deucalion.sha256sum.asc
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: deucalion
+        path: |
+          target/release/deucalion.dll
+          deucalion.sha256sum
+          deucalion.sha256sum.asc
+
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v3
+
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Deucalion ${{ github.ref_name }}
+        body: "# CHANGELOG"
+        draft: true
+        files: |
+          deucalion.dll
+          deucalion.sha256sum
+          deucalion.sha256sum.asc
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,9 @@
 name: Build
 on:
   push:
-    branches: [ signing_test ]
+    tags:
+    - 0.*
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
This workflow builds the release, computes a checksum and signs the checksum with the CI GPG key.