### PR TITLE
FIX: Do not emit duplicate packets for RECV

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Release
 on:
   push:
     tags:

--- a/src/hook/recv.rs
+++ b/src/hook/recv.rs
@@ -123,6 +123,10 @@ impl Hook {
         let ret = hook.get().expect(INVALID_MSG).call(a1, a2, a3, a4, a5);
 
         let ptr_frame: *const u8 = *(a1.add(16) as *const usize) as *const u8;
+        let offset: u32 = *(a1.add(28) as *const u32);
+        if offset != 0 {
+            return ret;
+        }
 
         match packet::extract_packets_from_frame(ptr_frame) {
             Ok(packets) => {


### PR DESCRIPTION
The parent function several hops up the call chain is called for every segment it pops off the network buffer. However DecompressPacket function is called as part of this, so each frame could be "decompressed" hundreds of times (although once it's already decompressed it's a no-op).

In this fix we look at the iteration offset so that we only process each frame once.