### PR TITLE
Add filtering logic for different packet types

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ This is the total length of the entire payload, including the length bytes.
 
 ### OP Types
 
-| OP  | Name  | Description                                                                                                                       |
-| --- | ----- | --------------------------------------------------------------------------------------------------------------------------------- |
-| 0   | Debug | Used for passing debug text messages.                                                                                             |
-| 1   | Ping  | Used to maintain a connection between the subscriber and Deucalion. Deucalion will echo the same payload when it receives a ping. |
-| 2   | Exit  | Used to signal Deucalion to unload itself from the host process. In most use cases, you will not need to send this op at all.     |
-| 3   | Recv  | When sent from Deucalion, contains the FFXIV packet received by the host process.                                                 |
-| 4   | Send  | When sent from Deucalion, contains the FFXIV packet sent by the host process.                                                     |
+| OP  | Name   | Description                                                                                                                       |
+| --- | ------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | Debug  | Used for passing debug text messages.                                                                                             |
+| 1   | Ping   | Used to maintain a connection between the subscriber and Deucalion. Deucalion will echo the same payload when it receives a ping. |
+| 2   | Exit   | Used to signal Deucalion to unload itself from the host process. In most use cases, you will not need to send this op at all.     |
+| 3   | Recv   | When sent from Deucalion, contains the FFXIV packet received by the host process.                                                 |
+| 4   | Send   | When sent from Deucalion, contains the FFXIV packet sent by the host process.                                                     |
+| 5   | Option | Used to configure per-subscriber filtering for packets.                                                                           |
 
 ### Channel
 
@@ -174,7 +175,7 @@ packets, you can compute the filter value:
 ```
 and send the payload:
 ```c
-Payload { OP: OP.Recv, CHANNEL: 54}
+Payload { OP: OP.Option, CHANNEL: 54, DATA: <empty>}
 // Deucalion: Filter set response
 Payload { OP: OP.Debug, CHANNEL: 0, DATA: u8"Packet filters set: 0b00110110" }
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ subscriber requests.
    broadcasted packets.
 1. Deucalion will close and unload itself once all subscribers are disconnected.
 
+> :information_source: By default, Deucalion's will not send you packets for
+> anything other than received Zone packets. To allow other packet types, please
+> see the [Option OP](#option-op) section.
+
 ## Payload Format
 
 All communication with Deucalion follows this length-delimited protocol (ranges
@@ -141,6 +145,39 @@ https://docs.rs/pelite/latest/pelite/pattern/fn.parse.html.
 ### Send OP
 
 What applies to `Recv` OP payloads also applies to `Send` OP payloads.
+
+### Option OP
+
+By default, Deucalion sets a per-subscriber filter that allows only `Recv`
+Zone payloads to be sent to the subscriber.
+
+Each subscriber can customize their own filter for what `Recv` or `Send` packets
+are sent by Deucalion. Other payload OPs such as `Debug` are not affected by
+this filter.
+
+Filters can be set by sending an `Option` OP with bitflags as the CHANNEL.
+
+| Flag   | Description                                          |
+| ------ | ---------------------------------------------------- |
+| 1 << 0 | Allows received Lobby packets.                       |
+| 1 << 1 | Allows received Zone packets.                        |
+| 1 << 2 | Allows received Chat packets.                        |
+| 1 << 3 | Allows sent Lobby packets.                           |
+| 1 << 4 | Allows sent Zone packets.                            |
+| 1 << 5 | Allows sent Chat packets.                            |
+| 1 << 6 | Allows other channels. Currently used for debugging. |
+
+For example, to allow received Zone, received Chat, sent Zone, and sent Chat
+packets, you can compute the filter value:
+```c
+54 == (1 << 1 | 1 << 2 | 1 << 4 | 1 << 5)
+```
+and send the payload:
+```c
+Payload { OP: OP.Recv, CHANNEL: 54}
+// Deucalion: Filter set response
+Payload { OP: OP.Debug, CHANNEL: 0, DATA: u8"Packet filters set: 0b00110110" }
+```
 
 #### Error Handling
 


### PR DESCRIPTION
Without a packet filter, subscribers that do not need every packet type may be flooded with noisy or irrelevant packets such as Lobby packets or sent Zone packets.

This change adds a default filter that allows only received Zone packets, and allows subscribers to each configure a filter for their own needs.