### PR TITLE
Improve logging in main and around sig scanning

### DIFF
--- a/src/hook/recv.rs
+++ b/src/hook/recv.rs
@@ -18,7 +18,7 @@ use super::packet;
 use super::waitgroup;
 use super::{Channel, HookError};
 
-use log::info;
+use log::error;
 
 type HookedFunction = unsafe extern "system" fn(*const u8, *const u8, usize, usize, usize) -> usize;
 
@@ -139,7 +139,7 @@ impl Hook {
                 }
             }
             Err(e) => {
-                info!("Could not process packet: {}", e)
+                error!("Could not process packet: {}", e)
             }
         }
 

--- a/src/hook/send.rs
+++ b/src/hook/send.rs
@@ -18,7 +18,7 @@ use super::packet;
 use super::waitgroup;
 use super::{Channel, HookError};
 
-use log::info;
+use log::error;
 
 type HookedFunction =
     unsafe extern "system" fn(*const u8, *const u8, usize, usize, usize, usize) -> usize;
@@ -114,7 +114,7 @@ impl Hook {
                 }
             }
             Err(e) => {
-                info!("Could not process packet: {}", e)
+                error!("Could not process packet: {}", e)
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ async fn main_with_result() -> Result<()> {
     let hs_clone = hs.clone();
     let state_clone = state.clone();
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel::<()>();
-    let msg_loop_future = tokio::spawn(async move {
+    let msg_loop_handle = tokio::spawn(async move {
         loop {
             let mut broadcast_rx = hs_clone.broadcast_rx.lock().await;
             select! {
@@ -139,9 +139,8 @@ async fn main_with_result() -> Result<()> {
 
     // Signal the msg loop to exit and shut down the hook
     drop(shutdown_tx);
-    msg_loop_future.await?;
-
     info!("Hook shutdown initiated...");
+    msg_loop_handle.await?;
     info!("Shut down!");
     Ok(())
 }


### PR DESCRIPTION
This PR also adds some refactors to clean up the unused code and to avoid code duplication. 

It adds logging for the signature used, the time spent scanning signatures, and emits logs at various parts of the lifecycle to aid in debugging.

Fixes #10

Here are what the new logs look like:
```
03:00:46 [INFO] Attempting to auto-initialize the hooks
03:00:46 [INFO] Scanning for RecvPacket sig: `E8 $ { ' } 4C 8B 43 10 41 8B 40 18`
03:00:46 [INFO] Found RecvPacket addr(s): [153fcf0, 1546f60, 1580fe0]
03:00:46 [INFO] Sig scan took 67.2561ms
03:00:46 [INFO] Scanning for SendPacket sig: `E8 $ { ' } 8B 53 2C 48 8D 8B`
03:00:46 [INFO] Found SendPacket addr(s): [1541120, 157f7f0]
03:00:46 [INFO] Sig scan took 66.1381ms
03:00:46 [INFO] Hooks initialized.
03:00:46 [INFO] Starting server on \\.\pipe\deucalion-101404
03:00:47 [INFO] New client connected: 0
03:00:59 [INFO] New client connected: 1
03:01:11 [INFO] client disconnected: 0
03:01:14 [INFO] client disconnected: 1
03:01:14 [INFO] Shutdown signal received
03:01:14 [INFO] Hook shutdown initiated...
03:01:14 [INFO] Shut down!
```