### PR TITLE
Refactor server code

### DIFF
--- a/src/bin/signal_exit.rs
+++ b/src/bin/signal_exit.rs
@@ -17,13 +17,13 @@ async fn main() {
 }
 
 async fn signal_pipe(pipe_name: &String) {
-    let client = Endpoint::connect(pipe_name)
+    let subscriber = Endpoint::connect(pipe_name)
         .await
-        .expect("Failed to connect client to server");
+        .expect("Failed to connect subscriber to server");
 
-    // Create a frame decoder that processes the client stream
+    // Create a frame decoder that processes the subscriber stream
     let codec = rpc::PayloadCodec::new();
-    let mut frames = Framed::new(client, codec);
+    let mut frames = Framed::new(subscriber, codec);
 
     // Handle the SERVER_HELLO message
     let peer_message = frames.next().await.unwrap();


### PR DESCRIPTION
This shouldn't affect the behavior of Deucalion at all, but it allows us to clean up a lot of unnecessary duplication of code by having the server impl handle all of its internal state.

Additionally, this PR adds a bunch of tests to ensure the stability of the server and adds more log lines around the shutdown logic of the server.