### PR TITLE
Add support for SendLobbyPacket and non-IPC segment types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ region = "3.0"
 once_cell = "1.17"
 binary-layout = "3.1.3"
 dirs = "4.0"
+strum = "0.24"
+strum_macros = "0.24"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [

--- a/src/hook/mod.rs
+++ b/src/hook/mod.rs
@@ -1,4 +1,3 @@
-use std::fmt::Display;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -10,6 +9,7 @@ use tokio::sync::{mpsc, Mutex};
 use pelite::{pattern, pe::PeView, ImageMap};
 
 use log::info;
+use strum_macros::Display;
 
 use crate::procloader::{find_pattern_matches, get_ffxiv_filepath};
 use crate::rpc;
@@ -17,36 +17,30 @@ use crate::rpc;
 mod packet;
 mod recv;
 mod send;
+mod send_lobby;
 mod waitgroup;
 
 pub struct State {
     recv_hook: recv::Hook,
     send_hook: send::Hook,
+    send_lobby_hook: send_lobby::Hook,
     wg: waitgroup::WaitGroup,
     pub broadcast_rx: Arc<Mutex<mpsc::UnboundedReceiver<rpc::Payload>>>,
 }
 
-pub enum Direction {
+#[derive(Display, Clone, Copy)]
+pub enum HookType {
     Recv,
     Send,
+    SendLobby,
 }
 
 #[repr(u32)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Display)]
 pub(self) enum Channel {
     Lobby,
     Zone,
     Chat,
-}
-
-impl Display for Channel {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
-        match *self {
-            Channel::Lobby => f.write_str("lobby"),
-            Channel::Zone => f.write_str("zone"),
-            Channel::Chat => f.write_str("chat"),
-        }
-    }
 }
 
 #[derive(Debug, Error)]
@@ -65,13 +59,14 @@ impl State {
         let hs = State {
             recv_hook: recv::Hook::new(broadcast_tx.clone(), wg.clone())?,
             send_hook: send::Hook::new(broadcast_tx.clone(), wg.clone())?,
+            send_lobby_hook: send_lobby::Hook::new(broadcast_tx.clone(), wg.clone())?,
             wg,
             broadcast_rx: Arc::new(Mutex::new(broadcast_rx)),
         };
         Ok(hs)
     }
 
-    pub fn initialize_hook(&self, sig_str: String, direction: Direction) -> Result<()> {
+    pub fn initialize_hook(&self, sig_str: String, hook_type: HookType) -> Result<()> {
         let pat =
             pattern::parse(&sig_str).context(format!("Invalid signature: \"{}\"", sig_str))?;
         let sig: &[pattern::Atom] = &pat;
@@ -80,9 +75,10 @@ impl State {
         let image_map = ImageMap::open(&ffxiv_file_path).unwrap();
         let pe_image = PeView::from_bytes(image_map.as_ref())?;
 
-        let sig_name = match direction {
-            Direction::Recv => "RecvPacket",
-            Direction::Send => "SendPacket",
+        let sig_name = match hook_type {
+            HookType::Recv => "RecvPacket",
+            HookType::Send => "SendPacket",
+            HookType::SendLobby => "SendLobbyPacket",
         };
         info!("Scanning for {} sig: `{}`", sig_name, sig_str);
         let scan_start = Instant::now();
@@ -90,15 +86,17 @@ impl State {
             .map_err(|e| format_err!("{}: {}", e, sig_str))?;
         info!("Sig scan took {:?}", scan_start.elapsed());
 
-        match direction {
-            Direction::Recv => self.recv_hook.setup(rvas),
-            Direction::Send => self.send_hook.setup(rvas),
+        match hook_type {
+            HookType::Recv => self.recv_hook.setup(rvas),
+            HookType::Send => self.send_hook.setup(rvas),
+            HookType::SendLobby => self.send_lobby_hook.setup(rvas),
         }
     }
 
     pub fn shutdown(&self) {
         self.recv_hook.shutdown();
         self.send_hook.shutdown();
+        self.send_lobby_hook.shutdown();
         // Wait for any hooks to finish what they're doing
         self.wg.wait();
     }

--- a/src/hook/recv.rs
+++ b/src/hook/recv.rs
@@ -131,11 +131,19 @@ impl Hook {
         match packet::extract_packets_from_frame(ptr_frame) {
             Ok(packets) => {
                 for packet in packets {
-                    let _ = self.data_tx.send(rpc::Payload {
-                        op: rpc::MessageOps::Recv,
-                        ctx: channel as u32,
-                        data: packet,
-                    });
+                    let payload = match packet {
+                        packet::Packet::IPC(data) => rpc::Payload {
+                            op: rpc::MessageOps::Recv,
+                            ctx: channel as u32,
+                            data,
+                        },
+                        packet::Packet::Other(data) => rpc::Payload {
+                            op: rpc::MessageOps::RecvOther,
+                            ctx: channel as u32,
+                            data,
+                        },
+                    };
+                    let _ = self.data_tx.send(payload);
                 }
             }
             Err(e) => {

--- a/src/hook/send.rs
+++ b/src/hook/send.rs
@@ -106,11 +106,19 @@ impl Hook {
         match packet::extract_packets_from_frame(ptr_frame) {
             Ok(packets) => {
                 for packet in packets {
-                    let _ = self.data_tx.send(rpc::Payload {
-                        op: rpc::MessageOps::Send,
-                        ctx: channel as u32,
-                        data: packet,
-                    });
+                    let payload = match packet {
+                        packet::Packet::IPC(data) => rpc::Payload {
+                            op: rpc::MessageOps::Send,
+                            ctx: channel as u32,
+                            data,
+                        },
+                        packet::Packet::Other(data) => rpc::Payload {
+                            op: rpc::MessageOps::SendOther,
+                            ctx: channel as u32,
+                            data,
+                        },
+                    };
+                    let _ = self.data_tx.send(payload);
                 }
             }
             Err(e) => {

--- a/src/hook/send_lobby.rs
+++ b/src/hook/send_lobby.rs
@@ -1,0 +1,105 @@
+use std::mem;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use tokio::sync::mpsc;
+
+use once_cell::sync::OnceCell;
+
+use retour;
+use retour::static_detour;
+
+use crate::rpc;
+
+use crate::procloader::get_ffxiv_handle;
+
+use super::packet;
+use super::waitgroup;
+use super::{Channel, HookError};
+
+use log::error;
+
+type HookedFunction = unsafe extern "system" fn(*const u8) -> usize;
+
+static_detour! {
+    static SendLobbyPacket: unsafe extern "system" fn(*const u8) -> usize;
+}
+
+#[derive(Clone)]
+pub struct Hook {
+    data_tx: mpsc::UnboundedSender<rpc::Payload>,
+
+    lobby_hook: Arc<OnceCell<&'static retour::StaticDetour<HookedFunction>>>,
+
+    wg: waitgroup::WaitGroup,
+}
+
+impl Hook {
+    pub fn new(
+        data_tx: mpsc::UnboundedSender<rpc::Payload>,
+        wg: waitgroup::WaitGroup,
+    ) -> Result<Hook> {
+        Ok(Hook {
+            data_tx,
+            lobby_hook: Arc::new(OnceCell::new()),
+            wg,
+        })
+    }
+
+    pub fn setup(&self, rvas: Vec<usize>) -> Result<()> {
+        if rvas.len() != 1 {
+            return Err(HookError::SignatureMatchFailed(rvas.len(), 1).into());
+        }
+        let mut ptrs: Vec<*const u8> = Vec::new();
+        for rva in rvas {
+            ptrs.push(get_ffxiv_handle()?.wrapping_offset(rva as isize));
+        }
+
+        let self_clone = self.clone();
+        let lobby_hook = unsafe {
+            let ptr_fn: HookedFunction = mem::transmute(ptrs[0] as *const ());
+            SendLobbyPacket.initialize(ptr_fn, move |a| self_clone.send_lobby_packet(a))?
+        };
+        if let Err(_) = self.lobby_hook.set(lobby_hook) {
+            return Err(HookError::SetupFailed(Channel::Lobby).into());
+        }
+
+        unsafe {
+            self.lobby_hook.get_unchecked().enable()?;
+        }
+        Ok(())
+    }
+
+    unsafe fn send_lobby_packet(&self, a1: *const u8) -> usize {
+        let _guard = self.wg.add();
+
+        let ptr_frame: *const u8 = *(a1.add(32) as *const usize) as *const u8;
+
+        match packet::extract_packets_from_frame(ptr_frame) {
+            Ok(packets) => {
+                for packet in packets {
+                    let _ = self.data_tx.send(rpc::Payload {
+                        op: rpc::MessageOps::Send,
+                        ctx: Channel::Lobby as u32,
+                        data: packet,
+                    });
+                }
+            }
+            Err(e) => {
+                error!("Could not process packet: {}", e)
+            }
+        }
+
+        const INVALID_MSG: &str = "Hook function was called without a valid hook";
+        return self.lobby_hook.get().expect(INVALID_MSG).call(a1);
+    }
+
+    pub fn shutdown(&self) {
+        unsafe {
+            if let Some(hook) = self.lobby_hook.get() {
+                let _ = hook.disable();
+            };
+        }
+    }
+}

--- a/src/hook/send_lobby.rs
+++ b/src/hook/send_lobby.rs
@@ -79,11 +79,19 @@ impl Hook {
         match packet::extract_packets_from_frame(ptr_frame) {
             Ok(packets) => {
                 for packet in packets {
-                    let _ = self.data_tx.send(rpc::Payload {
-                        op: rpc::MessageOps::Send,
-                        ctx: Channel::Lobby as u32,
-                        data: packet,
-                    });
+                    let payload = match packet {
+                        packet::Packet::IPC(data) => rpc::Payload {
+                            op: rpc::MessageOps::Send,
+                            ctx: Channel::Lobby as u32,
+                            data,
+                        },
+                        packet::Packet::Other(data) => rpc::Payload {
+                            op: rpc::MessageOps::SendOther,
+                            ctx: Channel::Lobby as u32,
+                            data,
+                        },
+                    };
+                    let _ = self.data_tx.send(payload);
                 }
             }
             Err(e) => {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -11,6 +11,8 @@ pub enum MessageOps {
     Recv,
     Send,
     Option,
+    RecvOther,
+    SendOther,
 }
 
 impl From<u8> for MessageOps {
@@ -22,6 +24,8 @@ impl From<u8> for MessageOps {
             3 => MessageOps::Recv,
             4 => MessageOps::Send,
             5 => MessageOps::Option,
+            6 => MessageOps::RecvOther,
+            7 => MessageOps::SendOther,
             _ => MessageOps::Debug,
         }
     }
@@ -128,6 +132,16 @@ mod tests {
                 data: vec![1, 2, 3],
             },
             Payload {
+                op: MessageOps::RecvOther,
+                ctx: 100,
+                data: vec![1, 2, 3],
+            },
+            Payload {
+                op: MessageOps::SendOther,
+                ctx: 100,
+                data: vec![1, 2, 3],
+            },
+            Payload {
                 op: MessageOps::Debug,
                 ctx: 100,
                 data: vec![1, 2, 3],
@@ -158,7 +172,9 @@ mod tests {
             12, 0, 0, 0, 3, 100, 0, 0, 0, 1, 2, 3, // Recv
             12, 0, 0, 0, 4, 100, 0, 0, 0, 1, 2, 3, // Send
             12, 0, 0, 0, 5, 100, 0, 0, 0, 1, 2, 3, // Option
-            12, 0, 0, 0, 6, 100, 0, 0, 0, 1, 2, 3, // Debug
+            12, 0, 0, 0, 6, 100, 0, 0, 0, 1, 2, 3, // RecvOther
+            12, 0, 0, 0, 7, 100, 0, 0, 0, 1, 2, 3, // SendOther
+            12, 0, 0, 0, 8, 100, 0, 0, 0, 1, 2, 3, // Catch-all debug
         ];
         let mut buf = BytesMut::from(data);
         let mut codec = PayloadCodec::new();

--- a/src/server.rs
+++ b/src/server.rs
@@ -113,6 +113,8 @@ fn allow_broadcast(op: rpc::MessageOps, channel: u32, filter: u32) -> bool {
             2 => (filter & BroadcastFilter::AllowChatSend as u32) > 0,
             _ => (filter & BroadcastFilter::AllowOther as u32) > 0,
         },
+        rpc::MessageOps::RecvOther => (filter & BroadcastFilter::AllowOther as u32) > 0,
+        rpc::MessageOps::SendOther => (filter & BroadcastFilter::AllowOther as u32) > 0,
         // All other message ops are always allowed
         _ => true,
     }
@@ -453,6 +455,8 @@ mod tests {
             (BroadcastFilter::AllowZoneSend, rpc::MessageOps::Send, 1),
             (BroadcastFilter::AllowChatSend, rpc::MessageOps::Send, 2),
             (BroadcastFilter::AllowOther, rpc::MessageOps::Recv, 100),
+            (BroadcastFilter::AllowOther, rpc::MessageOps::RecvOther, 0),
+            (BroadcastFilter::AllowOther, rpc::MessageOps::SendOther, 0),
         ];
         const ALLOW_EVERYTHING: u32 = 0xFF;
         for (filter, op, ctx) in configurations {


### PR DESCRIPTION
This change adds the ability to receive the Lobby channel for Send and segments that are not of type `SEGMENTTYPE_IPC`.

There are a few behavioral changes as a result of this change, though
they should not be breaking for standard use cases.

1. Deucalion now accepts a sig for SendLobbyPacket via sending a Payload
   with OP `Send` and CHANNEL `0` (Lobby). Deucalion accepts a sig for
   SendPacket via a Payload with OP `Send` and any CHANNEL != 0.
2. The SERVER HELLO message has been shortened like so:
   `SERVER HELLO. HOOK STATUS: RECV {}. SEND {}. SEND_LOBBY {}.`
3. Deucalion now emits two new OP types: `RecvOther` and `SendOther`. Subscribers can opt-into receiving them with the Option flag for allowing other packets (`1 << 6`).