### PR TITLE
Add ability to set nicknames for individual subscribers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ types:
 | 1       | Zone  |
 | 2       | Chat  |
 
+
+For the `Debug` OP, the CHANNEL 9000 indicates the `HELLO` CHANNEL.
+
 ### Data
 
 For payloads with OP `Debug`, the payload is simply debug-logged.
@@ -117,8 +120,25 @@ CHANNEL.
 
 ### Debug OP
 
-Any payload sent with the `Debug` OP will be simply be debug-logged and an `OK`
-response will be sent back to the requesting subscriber.
+Any payload sent with the `Debug` OP with a CHANNEL other than `HELLO` will be
+simply be debug-logged and an `OK` response will be sent back to the requesting
+subscriber.
+
+For payloads with the `Debug` OP and the `HELLO` channel, the DATA sent will
+be set as the nickname for the current subscriber.
+
+These are the restrictions on the values of nickname that are accepted:
+- The bytes in DATA must be valid UTF-8.
+- Must contain only ASCII alphanumeric characters or underscores (`^[A-Za-z0-9_]+$`)
+- Must be 30 characters or less
+- Names are allowed to be the same as other subscribers.
+
+For example:
+```c
+Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"TEST_CLIENT" }
+// Deucalion: Nickname set response
+Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"CHANGED NICKNAME: TEST_CLIENT (subscriber 0)" }
+```
 
 ### Ping OP
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,7 @@ async fn main_with_result() -> Result<()> {
     drop(shutdown_tx);
     info!("Shutting down broadcast loop...");
     msg_loop_handle.await?;
-    info!("Shut down!");
+    info!("Shutting down...");
     Ok(())
 }
 
@@ -220,6 +220,7 @@ unsafe extern "system" fn main(dll_base_addr: LPVOID) -> u32 {
         error!("Panic happened: {:?}", cause);
         pause();
     }
+    info!("Shut down!");
     #[cfg(debug_assertions)]
     wincon::FreeConsole();
     libloaderapi::FreeLibraryAndExitThread(dll_base_addr as HMODULE, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@ const SEND_SIG: &str = "E8 $ { ' } 8B 53 2C 48 8D 8B";
 const SEND_LOBBY_SIG: &str = "40 53 48 83 EC 20 44 8B 41 28";
 
 fn handle_payload(payload: rpc::Payload, hs: Arc<hook::State>) -> Result<()> {
-    info!("Received payload from subscriber: {:?}", payload);
     if payload.op == rpc::MessageOps::Recv || payload.op == rpc::MessageOps::Send {
         let hook_type = match payload.op {
             rpc::MessageOps::Recv => hook::HookType::Recv,
@@ -189,7 +188,7 @@ fn logging_setup() -> Result<()> {
 
     #[cfg(debug_assertions)]
     {
-        let _ = CombinedLogger::init(vec![
+        CombinedLogger::init(vec![
             SimpleLogger::new(LevelFilter::Debug, simplelog::Config::default()),
             WriteLogger::new(LevelFilter::Debug, simplelog::Config::default(), log_file),
         ])?;

--- a/src/server.rs
+++ b/src/server.rs
@@ -395,14 +395,14 @@ impl Server {
         let hello_string = self.state.lock().await.server_hello_string();
 
         let mut subscriber = Subscriber { id, frames, rx };
+        let mut nickname = format!("subscriber {}", subscriber.id);
 
         subscriber
             .send_dbg_payload(HELLO_CHANNEL, hello_string.into())
-            .await?;
+            .await
+            .map_err(|e| format_err!("Could not send SERVER HELLO to {nickname}: {e}"))?;
 
-        info!("New subscriber connected: {}", subscriber.id);
-
-        let mut nickname = format!("subscriber {}", subscriber.id);
+        info!("New subscriber connected: {nickname}");
 
         match self
             .subscriber_msg_loop(&mut subscriber, &mut nickname, payload_handler)


### PR DESCRIPTION
This PR allows Subscribers to optionally specify a nickname.

For example, setting a nickname like follows:
```c
Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"TEST_CLIENT" }
```
will result in a response:
```c
Payload { OP: OP.Debug, CHANNEL: 9000, CHANGED NICKNAME: TEST_CLIENT (subscriber 0) }
```

and log messages will contain the subscriber nickname like so:

```
[INFO] New subscriber connected: 0
[INFO] Filter set for TEST_CLIENT (subscriber 0): 0b11111111
[INFO] Disconnected: TEST_CLIENT (subscriber 0)
[INFO] Shutting down server because last subscriber disconnected
```

