### PR TITLE
Add package version to SERVER HELLO

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ to the subscriber.
 
 ```c
 // Deucalion: Connection established message.
-Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. HOOK STATUS: RECV ON. SEND ON. SEND_LOBBY ON." }
+Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. VERSION: 1.0.0. HOOK STATUS: RECV ON. SEND ON. SEND_LOBBY ON." }
 // Deucalion: Data streamed to all subscribers
 Payload { OP: OP.Recv, CHANNEL: 1, DATA: deucalion_segment }
 ...
@@ -251,7 +251,7 @@ Payload { OP: OP.Recv, CHANNEL: 1, DATA: deucalion_segment }
 ### Example when Deucalion requires sigs
 ```c
 // Deucalion: Connection established message.
-Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. HOOK STATUS: RECV OFF. SEND OFF. SEND_LOBBY OFF." }
+Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. VERSION: 1.0.0. HOOK STATUS: RECV OFF. SEND OFF. SEND_LOBBY OFF." }
 // Subscriber: Request with an invalid sig.
 Payload { OP: OP.Recv, CHANNEL: 1, DATA: u8"invalid sig" }
 // Deucalion: Response with an invalid sig error.
@@ -271,7 +271,7 @@ If the Recv hook is already initialized, then the following scenario can happen:
 
 ```c
 // Deucalion: Connection established message.
-Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. RECV ON. SEND ON. SEND_LOBBY ON." }
+Payload { OP: OP.Debug, CHANNEL: 9000, DATA: u8"SERVER HELLO. VERSION: 1.0.0. RECV ON. SEND ON. SEND_LOBBY ON." }
 // Deucalion: Data streamed to all subscribers
 Payload { OP: OP.Recv, CHANNEL: 1, DATA: deucalion_segment }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -263,7 +263,8 @@ impl State {
 
     fn server_hello_string(&self) -> String {
         format!(
-            "SERVER HELLO. HOOK STATUS: RECV {}. SEND {}. SEND_LOBBY {}.",
+            "SERVER HELLO. VERSION: {}. HOOK STATUS: RECV {}. SEND {}. SEND_LOBBY {}.",
+            crate::VERSION,
             Self::hook_status_string(self.recv_hooked),
             Self::hook_status_string(self.send_hooked),
             Self::hook_status_string(self.send_lobby_hooked),
@@ -593,8 +594,11 @@ mod tests {
 
         let fmt_msg = |a, b, c| {
             format!(
-                "SERVER HELLO. HOOK STATUS: RECV {}. SEND {}. SEND_LOBBY {}.",
-                a, b, c
+                "SERVER HELLO. VERSION: {}. HOOK STATUS: RECV {}. SEND {}. SEND_LOBBY {}.",
+                crate::VERSION,
+                a,
+                b,
+                c
             )
         };
         let combinations = vec![


### PR DESCRIPTION
Adds ` VERSION: {SEMVER}. ` after the `SERVER HELLO. ` message. May be used by clients to detect right away if the currently injected version of Deucalion is the requisite version. Lack of the version indicates Deucalion is out of date.