### PR TITLE
Make Deucalion send de-obfuscated packets instead of the original network payload

### DIFF
--- a/deucalion/Cargo.toml
+++ b/deucalion/Cargo.toml
@@ -51,6 +51,7 @@ binary-layout = "3.2"
 dirs = "5.0"
 strum = "0.26"
 strum_macros = "0.26"
+crossbeam-channel = "0.5"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [

--- a/deucalion/src/hook/create_target.rs
+++ b/deucalion/src/hook/create_target.rs
@@ -1,0 +1,250 @@
+//! It doesn't actually matter what function this is hooking, as long as it's
+//! right before the giant switch that processes packets.
+
+use std::{
+    arch::asm,
+    mem,
+    sync::{
+        atomic::{AtomicPtr, AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use anyhow::{format_err, Result};
+use log::{error, warn};
+use retour::RawDetour;
+use tokio::sync::mpsc;
+
+use super::{packet, waitgroup, Channel, HookError};
+use crate::{procloader::get_ffxiv_handle, rpc};
+
+use std::sync::LazyLock;
+
+// Once initialized, it's important to keep this in memory so that any
+// stray calls to the hook still have a valid trampoline to call.
+static DETOUR: LazyLock<CustomDetour> = LazyLock::new(CustomDetour::new);
+
+/// Custom static detour designed specifically for CreateTarget. If the
+/// signature of the function being hooked changes non-trivially this will
+/// need to be updated.
+///
+/// Implementation mostly borrowed from retour::StaticDetour.
+/// Copyright (C) 2017 Elliott Linder.
+pub struct CustomDetour {
+    // Closure arguments: (packet_data, return_addr, a1)
+    #[allow(clippy::type_complexity)]
+    closure: AtomicPtr<Box<dyn Fn(usize, usize, usize) -> usize>>,
+    detour: AtomicPtr<RawDetour>,
+}
+
+impl CustomDetour {
+    fn new() -> Self {
+        CustomDetour {
+            closure: AtomicPtr::new(std::ptr::null_mut()),
+            detour: AtomicPtr::new(std::ptr::null_mut()),
+        }
+    }
+
+    /// Initializes the detour and sets the closure to be called when the detour
+    /// is enabled.
+    pub unsafe fn initialize<D>(&self, target: *const (), closure: D) -> Result<()>
+    where
+        D: Fn(usize, usize, usize) -> usize + Send + 'static,
+    {
+        let mut detour = Box::new(RawDetour::new(target, create_target as *const ())?);
+        if self
+            .detour
+            .compare_exchange(
+                std::ptr::null_mut(),
+                &mut *detour,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_err()
+        {
+            Err(HookError::AlreadyInitialized)?;
+        }
+
+        self.closure
+            .store(Box::into_raw(Box::new(Box::new(closure))), Ordering::SeqCst);
+        mem::forget(detour);
+        Ok(())
+    }
+
+    /// Enables the detour.
+    pub unsafe fn enable(&self) -> Result<()> {
+        self.detour
+            .load(Ordering::SeqCst)
+            .as_ref()
+            .ok_or(HookError::NotInitialized)?
+            .enable()?;
+        Ok(())
+    }
+
+    /// Disables the detour.
+    pub unsafe fn disable(&self) -> Result<()> {
+        self.detour
+            .load(Ordering::SeqCst)
+            .as_ref()
+            .ok_or(HookError::NotInitialized)?
+            .disable()?;
+        Ok(())
+    }
+
+    /// Calls the trampoline for the function being hooked. Ensure the signature
+    /// of this function matches the signature of the function being hooked.
+    unsafe fn call_trampoline(&self, source_actor: usize) -> Result<usize> {
+        let trampoline: fn(usize) -> usize = mem::transmute(
+            self.detour
+                .load(Ordering::SeqCst)
+                .as_ref()
+                .ok_or(HookError::NotInitialized)?
+                .trampoline(),
+        );
+        Ok(trampoline(source_actor))
+    }
+
+    /// Calls the closure that was set for the detour.
+    unsafe fn call_closure(
+        &self,
+        packet_data: usize,
+        return_addr: usize,
+        source_actor: usize,
+    ) -> Result<usize> {
+        let closure = self
+            .closure
+            .load(Ordering::SeqCst)
+            .as_ref()
+            .ok_or(HookError::NotInitialized)?;
+        Ok(closure(packet_data, return_addr, source_actor))
+    }
+}
+
+impl Drop for CustomDetour {
+    fn drop(&mut self) {
+        let previous = self.closure.swap(std::ptr::null_mut(), Ordering::Relaxed);
+        if !previous.is_null() {
+            mem::drop(unsafe { Box::from_raw(previous) });
+        }
+
+        let previous = self.detour.swap(std::ptr::null_mut(), Ordering::Relaxed);
+        if !previous.is_null() {
+            unsafe {
+                let _ = Box::from_raw(previous);
+            };
+        }
+    }
+}
+
+unsafe extern "C" {
+    #[link_name = "llvm.returnaddress"]
+    unsafe fn return_address(a: i32) -> *const u8;
+}
+
+unsafe extern "system" fn create_target(source_actor: usize) -> usize {
+    let packet_data: *const u8;
+    asm!("mov {0}, rsi", out(reg) packet_data);
+
+    let return_addr = return_address(0);
+
+    DETOUR
+        .call_closure(packet_data as usize, return_addr as usize, source_actor)
+        .unwrap_or_else(|e| {
+            error!("Error in CreateTarget closure: {e}");
+            0
+        })
+}
+
+#[derive(Clone)]
+pub struct Hook {
+    data_tx: mpsc::UnboundedSender<rpc::Payload>,
+    deobf_queue_rx: crossbeam_channel::Receiver<packet::Packet>,
+    wg: waitgroup::WaitGroup,
+    parent_ptr: Arc<AtomicUsize>,
+}
+
+impl Hook {
+    pub fn new(
+        data_tx: mpsc::UnboundedSender<rpc::Payload>,
+        deobf_queue_rx: crossbeam_channel::Receiver<packet::Packet>,
+        wg: waitgroup::WaitGroup,
+    ) -> Result<Hook> {
+        Ok(Hook {
+            data_tx,
+            deobf_queue_rx,
+            wg,
+            parent_ptr: Arc::new(AtomicUsize::new(0)),
+        })
+    }
+
+    pub fn setup(&self, parent_rva: usize, rvas: Vec<usize>) -> Result<()> {
+        if rvas.len() != 1 {
+            return Err(HookError::SignatureMatchFailed(rvas.len(), 1).into());
+        }
+        let ffxiv_handle = get_ffxiv_handle()?;
+        let fn_ptr = ffxiv_handle.wrapping_add(rvas[0]);
+        let parent_ptr: usize = ffxiv_handle.wrapping_add(parent_rva) as usize;
+        self.parent_ptr
+            .compare_exchange(0, parent_ptr, Ordering::SeqCst, Ordering::SeqCst)
+            .map_err(|_| format_err!("Could not initialize CreateTarget hook"))?;
+
+        let self_clone = self.clone();
+        unsafe {
+            DETOUR.initialize(fn_ptr as *const (), move |a, b, c| {
+                self_clone.hook_handler(a, b, c)
+            })?;
+            DETOUR.enable()?;
+        }
+
+        Ok(())
+    }
+
+    unsafe fn hook_handler(
+        &self,
+        packet_data: usize,
+        return_addr: usize,
+        source_actor: usize,
+    ) -> usize {
+        let _guard = self.wg.add();
+        let packet_data = packet_data as *const u8;
+        let return_addr = return_addr as *const u8;
+        let parent_ptr = self.parent_ptr.load(Ordering::SeqCst) as *const u8;
+
+        if parent_ptr.offset_from(return_addr).abs() < 0x2000 {
+            if let Ok(expected_packet) = self.deobf_queue_rx.try_recv() {
+                match packet::reconstruct_deobfuscated_packet(
+                    expected_packet,
+                    source_actor as u32,
+                    packet_data,
+                ) {
+                    Ok(reconstructed_packet) => {
+                        if let packet::Packet::Ipc(data) = reconstructed_packet {
+                            let _ = self.data_tx.send(rpc::Payload {
+                                op: rpc::MessageOps::Recv,
+                                ctx: Channel::Zone as u32,
+                                data,
+                            });
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Failed to reconstruct deobfuscated packet: {e}");
+                    }
+                }
+            } else {
+                let opcode: u16 = *(packet_data.byte_offset(2) as *const u16);
+                warn!("Processing deobfuscated packet {opcode}, but no packet was expected");
+            }
+        }
+
+        DETOUR.call_trampoline(source_actor).unwrap_or_else(|e| {
+            error!("{e}");
+            0
+        })
+    }
+
+    pub fn shutdown() {
+        if let Err(e) = unsafe { DETOUR.disable() } {
+            error!("Error disabling CreateTarget hook: {e}");
+        }
+    }
+}

--- a/deucalion/src/hook/create_target.rs
+++ b/deucalion/src/hook/create_target.rs
@@ -141,9 +141,16 @@ unsafe extern "C" {
     unsafe fn return_address(a: i32) -> *const u8;
 }
 
-unsafe extern "system" fn create_target(source_actor: usize) -> usize {
+unsafe extern "system" fn create_target(a1: usize) -> usize {
+    let source_actor: usize;
     let packet_data: *const u8;
-    asm!("mov {0}, rsi", out(reg) packet_data);
+    asm!("
+        # Ensure rsi is preserved before here
+        mov r14, {0}
+        mov {1}, rsi",
+        in(reg) a1,
+        out(reg) packet_data,
+        out("r14") source_actor);
 
     let return_addr = return_address(0);
 

--- a/deucalion/src/hook/mod.rs
+++ b/deucalion/src/hook/mod.rs
@@ -14,6 +14,7 @@ use strum_macros::Display;
 use crate::procloader::{find_pattern_matches, get_ffxiv_filepath};
 use crate::rpc;
 
+mod create_target;
 mod packet;
 mod recv;
 mod send;
@@ -24,6 +25,7 @@ pub struct State {
     recv_hook: recv::Hook,
     send_hook: send::Hook,
     send_lobby_hook: send_lobby::Hook,
+    create_target_hook: create_target::Hook,
     wg: waitgroup::WaitGroup,
     pub broadcast_rx: Arc<Mutex<mpsc::UnboundedReceiver<rpc::Payload>>>,
 }
@@ -33,6 +35,7 @@ pub enum HookType {
     Recv,
     Send,
     SendLobby,
+    CreateTarget,
 }
 
 #[repr(u32)]
@@ -47,17 +50,23 @@ enum Channel {
 enum HookError {
     #[error("number of signature matches is incorrect: {0} != {1}")]
     SignatureMatchFailed(usize, usize),
+    #[error("enabled detour encountered uninitialized state")]
+    NotInitialized,
+    #[error("detour already initialized")]
+    AlreadyInitialized,
 }
 
 impl State {
     pub fn new() -> Result<State> {
         let (broadcast_tx, broadcast_rx) = mpsc::unbounded_channel::<rpc::Payload>();
+        let (deobf_queue_tx, deobf_queue_rx) = crossbeam_channel::unbounded::<packet::Packet>();
 
         let wg = waitgroup::WaitGroup::new();
         let hs = State {
-            recv_hook: recv::Hook::new(broadcast_tx.clone(), wg.clone())?,
+            recv_hook: recv::Hook::new(broadcast_tx.clone(), deobf_queue_tx, wg.clone())?,
             send_hook: send::Hook::new(broadcast_tx.clone(), wg.clone())?,
-            send_lobby_hook: send_lobby::Hook::new(broadcast_tx, wg.clone())?,
+            send_lobby_hook: send_lobby::Hook::new(broadcast_tx.clone(), wg.clone())?,
+            create_target_hook: create_target::Hook::new(broadcast_tx, deobf_queue_rx, wg.clone())?,
             wg,
             broadcast_rx: Arc::new(Mutex::new(broadcast_rx)),
         };
@@ -76,6 +85,7 @@ impl State {
             HookType::Recv => "RecvPacket",
             HookType::Send => "SendPacket",
             HookType::SendLobby => "SendLobbyPacket",
+            HookType::CreateTarget => "CreateTarget",
         };
         info!("Scanning for {sig_name} sig: `{sig_str}`");
         let scan_start = Instant::now();
@@ -87,6 +97,19 @@ impl State {
             HookType::Recv => self.recv_hook.setup(rvas),
             HookType::Send => self.send_hook.setup(rvas),
             HookType::SendLobby => self.send_lobby_hook.setup(rvas),
+            HookType::CreateTarget => {
+                info!("Scanning for {sig_name} caller: `{sig_str}`");
+                let scan_start = Instant::now();
+                let parent_rvas = find_pattern_matches(sig_name, sig, pe_image, false)
+                    .map_err(|e| format_err!("{}: {}", e, sig_str))?;
+                if parent_rvas.len() != 1 {
+                    return Err(HookError::SignatureMatchFailed(parent_rvas.len(), 1).into());
+                }
+                info!("Sig scan took {:?}", scan_start.elapsed());
+                self.create_target_hook.setup(parent_rvas[0], rvas)?;
+                self.recv_hook.set_create_target_hook_enabled(true);
+                Ok(())
+            }
         }
     }
 
@@ -95,6 +118,7 @@ impl State {
         recv::Hook::shutdown();
         send::Hook::shutdown();
         send_lobby::Hook::shutdown();
+        create_target::Hook::shutdown();
         // Wait for any hooks to finish what they're doing
         self.wg.wait();
     }

--- a/deucalion/src/hook/packet.rs
+++ b/deucalion/src/hook/packet.rs
@@ -56,12 +56,20 @@ define_layout!(deucalion_segment, LittleEndian, {
 
 pub(super) enum Packet {
     Ipc(Vec<u8>),
+    ObfuscatedIpc {
+        deucalion_segment_header: Vec<u8>,
+        opcode: u16,
+        data_len: usize,
+    },
     Other(Vec<u8>),
 }
 
 /// Extract packets from a pointer to a frame. Ensure ptr_frame is a valid
 /// pointer or the process will crash!
-pub(super) unsafe fn extract_packets_from_frame(ptr_frame: *const u8) -> Result<Vec<Packet>> {
+pub(super) unsafe fn extract_packets_from_frame(
+    ptr_frame: *const u8,
+    require_deobfuscation: bool,
+) -> Result<Vec<Packet>> {
     if ptr_frame.is_null() {
         return Err(format_err!(
             "hook was called with a null pointer. Skipping."
@@ -109,11 +117,17 @@ pub(super) unsafe fn extract_packets_from_frame(ptr_frame: *const u8) -> Result<
             // If IPC segment type, decode it and wrap it with a deucalion_segment
             let segment_header = segment.header();
             let deucalion_header_size = deucalion_segment_header::SIZE.unwrap();
-            let payload_len = segment_size as usize - segment_header_size + deucalion_header_size;
 
+            let payload_len = if require_deobfuscation {
+                deucalion_header_size
+            } else {
+                deucalion_header_size + segment_size as usize - segment_header_size
+            };
             let mut dst = Vec::<u8>::with_capacity(payload_len);
             let buf = dst.spare_capacity_mut();
             let buf: &mut [u8] = mem::transmute(buf);
+            dst.set_len(payload_len);
+
             let mut deucalion_segment = deucalion_segment::View::new(buf);
             let mut dsh = deucalion_segment.header_mut();
             dsh.source_actor_mut()
@@ -122,10 +136,19 @@ pub(super) unsafe fn extract_packets_from_frame(ptr_frame: *const u8) -> Result<
                 .write(segment_header.target_actor().read());
             dsh.timestamp_mut().write(frame_header.timestamp().read());
 
-            deucalion_segment.data_mut().copy_from_slice(segment.data());
-
-            dst.set_len(payload_len);
-            packets.push(Packet::Ipc(dst));
+            if require_deobfuscation {
+                let ipc_packet = ipc_packet::View::new(segment.data());
+                let opcode = ipc_packet.header().opcode().read();
+                let data_len = segment.data().len();
+                packets.push(Packet::ObfuscatedIpc {
+                    deucalion_segment_header: dst,
+                    opcode,
+                    data_len,
+                });
+            } else {
+                deucalion_segment.data_mut().copy_from_slice(segment.data());
+                packets.push(Packet::Ipc(dst));
+            }
         } else {
             // Otherwise just copy the segment as-is
             let dst = Vec::from(segment_bytes);
@@ -133,4 +156,153 @@ pub(super) unsafe fn extract_packets_from_frame(ptr_frame: *const u8) -> Result<
         }
     }
     Ok(packets)
+}
+
+pub(super) unsafe fn reconstruct_deobfuscated_packet(
+    expected_packet: Packet,
+    source_actor: u32,
+    data: *const u8,
+) -> Result<Packet> {
+    if let Packet::ObfuscatedIpc {
+        deucalion_segment_header,
+        opcode,
+        data_len,
+    } = expected_packet
+    {
+        let header = deucalion_segment_header::View::new(&deucalion_segment_header);
+        let expected_source_actor = header.source_actor().read();
+        if source_actor != expected_source_actor {
+            return Err(format_err!(
+                "source_actor mismatch: expected {}, got {}",
+                expected_source_actor,
+                source_actor
+            ));
+        }
+        let data_slice = slice::from_raw_parts(data, data_len);
+        let data = ipc_packet::View::new(data_slice);
+        if data.header().opcode().read() != opcode {
+            return Err(format_err!(
+                "opcode mismatch: expected {}, got {}",
+                data.header().opcode().read(),
+                opcode
+            ));
+        }
+
+        let header_len = deucalion_segment_header.len();
+        let mut dst = Vec::<u8>::with_capacity(header_len + data_len);
+        let buf = dst.spare_capacity_mut();
+        let buf: &mut [u8] = mem::transmute(buf);
+        buf[..header_len].copy_from_slice(&deucalion_segment_header);
+        buf[header_len..].copy_from_slice(data_slice);
+        dst.set_len(header_len + data_len);
+
+        return Ok(Packet::Ipc(dst));
+    }
+
+    Err(format_err!("packet is not an obfuscated IPC packet"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const DUMMY_FRAME_DATA: [u8; 80] = [
+        0x52, 0x52, 0xa0, 0x41, 0xff, 0x5d, 0x46, 0xe2, // magic (part 1)
+        0x7f, 0x2a, 0x64, 0x4d, 0x7b, 0x99, 0xc4, 0x75, // magic (part 2)
+        0xe6, 0xf6, 0x93, 0xda, 0x59, 0x01, 0x00, 0x00, // timestamp
+        0x50, 0x00, 0x00, 0x00, // size
+        0x00, 0x00, // connection_type
+        0x01, 0x00, // segment_count
+        0x01, 0x00, // unknown_20 and compression
+        0x00, 0x00, // unknown_22
+        0x00, 0x00, 0x00, 0x00, // decompressed_length
+        // segment
+        0x28, 0x00, 0x00, 0x00, // size
+        0x01, 0x02, 0x03, 0x04, // source_actor
+        0x05, 0x06, 0x07, 0x08, // target_actor
+        0x03, 0x00, // segment_type
+        0x00, 0x00, // padding
+        // ipc_header
+        0x14, 0x00, // reserved
+        0x42, 0x01, // opcode
+        0x00, 0x00, // padding
+        0x22, 0x00, // server_id
+        0x00, 0x00, 0x00, 0x00, // timestamp
+        0x00, 0x00, 0x00, 0x00, // padding1
+        0x15, 0xCD, 0x5B, 0x07, 0x42, 0xe0, 0x89, 0x58, // ipc_packet->data
+    ];
+
+    #[test]
+    fn test_extract_packets_from_frame_without_obfuscation() {
+        let packets =
+            unsafe { extract_packets_from_frame(DUMMY_FRAME_DATA.as_ptr(), false).unwrap() };
+        assert_eq!(packets.len(), 1);
+        if let Packet::Ipc(data) = &packets[0] {
+            let segment = deucalion_segment::View::new(data);
+            assert_eq!(segment.header().source_actor().read(), 0x04030201);
+            assert_eq!(segment.header().target_actor().read(), 0x08070605);
+            // Ensure the timestamp matches the frame timestamp
+            assert_eq!(segment.header().timestamp().read(), 0x159da93f6e6);
+            let ipc = ipc_packet::View::new(segment.data());
+            assert_eq!(ipc.header().opcode().read(), 0x142);
+            assert_eq!(ipc.header().server_id().read(), 34);
+            assert_eq!(ipc.data().len(), 8);
+        } else {
+            panic!("expected an Ipc Packet");
+        }
+    }
+
+    #[test]
+    fn test_extract_packets_from_frame_with_obfuscation() {
+        let packets =
+            unsafe { extract_packets_from_frame(DUMMY_FRAME_DATA.as_ptr(), true).unwrap() };
+        assert_eq!(packets.len(), 1);
+        if let Packet::ObfuscatedIpc {
+            deucalion_segment_header,
+            opcode,
+            data_len,
+        } = &packets[0]
+        {
+            let header = deucalion_segment_header::View::new(deucalion_segment_header);
+            assert_eq!(header.source_actor().read(), 0x04030201);
+            assert_eq!(header.target_actor().read(), 0x08070605);
+            // Ensure the timestamp matches the frame timestamp
+            assert_eq!(header.timestamp().read(), 0x159da93f6e6);
+            assert_eq!(*opcode, 0x142);
+            assert_eq!(*data_len, 24);
+        } else {
+            panic!("expected an ObfuscatedIpc Packet");
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_deobfuscated_packet() {
+        let packet = Packet::ObfuscatedIpc {
+            deucalion_segment_header: vec![
+                0x01, 0x02, 0x03, 0x04, // source_actor
+                0x05, 0x06, 0x07, 0x08, // target_actor
+                0xe6, 0xf6, 0x93, 0xda, 0x59, 0x01, 0x00, 0x00, // timestamp
+            ],
+            opcode: 0x142,
+            data_len: 24,
+        };
+
+        let reconstructed = unsafe {
+            reconstruct_deobfuscated_packet(packet, 0x04030201, DUMMY_FRAME_DATA[56..].as_ptr())
+                .unwrap()
+        };
+
+        if let Packet::Ipc(data) = reconstructed {
+            let segment = deucalion_segment::View::new(data);
+            assert_eq!(segment.header().source_actor().read(), 0x04030201);
+            assert_eq!(segment.header().target_actor().read(), 0x08070605);
+            // Ensure the timestamp matches the frame timestamp
+            assert_eq!(segment.header().timestamp().read(), 0x159da93f6e6);
+            let ipc = ipc_packet::View::new(segment.data());
+            assert_eq!(ipc.header().opcode().read(), 0x142);
+            assert_eq!(ipc.header().server_id().read(), 34);
+            assert_eq!(ipc.data().len(), 8);
+        } else {
+            panic!("expected an Ipc Packet");
+        }
+    }
 }

--- a/deucalion/src/hook/send.rs
+++ b/deucalion/src/hook/send.rs
@@ -72,7 +72,7 @@ impl Hook {
 
         let ptr_frame: *const u8 = *(a1.add(32) as *const usize) as *const u8;
 
-        match packet::extract_packets_from_frame(ptr_frame) {
+        match packet::extract_packets_from_frame(ptr_frame, false) {
             Ok(packets) => {
                 for packet in packets {
                     let payload = match packet {
@@ -86,6 +86,7 @@ impl Hook {
                             ctx: channel as u32,
                             data,
                         },
+                        _ => panic!("We shouldn't ever need deobfuscation here."),
                     };
                     let _ = self.data_tx.send(payload);
                 }

--- a/deucalion/src/hook/send_lobby.rs
+++ b/deucalion/src/hook/send_lobby.rs
@@ -63,7 +63,7 @@ impl Hook {
 
         let ptr_frame: *const u8 = *(a1.add(32) as *const usize) as *const u8;
 
-        match packet::extract_packets_from_frame(ptr_frame) {
+        match packet::extract_packets_from_frame(ptr_frame, false) {
             Ok(packets) => {
                 for packet in packets {
                     let payload = match packet {
@@ -77,6 +77,7 @@ impl Hook {
                             ctx: Channel::Lobby as u32,
                             data,
                         },
+                        _ => panic!("We shouldn't ever need deobfuscation here."),
                     };
                     let _ = self.data_tx.send(payload);
                 }


### PR DESCRIPTION
Adds a new special hook to grab de-obfuscated packet data before it has been processed by the game's packet handler.

This still hooks the packet decompression functions for the frame data, but it will reconcile packets one-to-one with the ones intercepted by the special hook in the game's packet handler so that the final result is a de-obfuscated packet.