### PR TITLE
Add safeguards for when packet queue becomes out of sync with packet dispatch

### DIFF
--- a/deucalion/src/hook/create_target.rs
+++ b/deucalion/src/hook/create_target.rs
@@ -215,7 +215,7 @@ impl Hook {
         source_actor: usize,
     ) -> usize {
         let _guard = self.wg.add();
-        let packet_data = packet_data as *const u8;
+        let packet_data = packet_data as *mut u8;
         let return_addr = return_addr as *const u8;
         let parent_ptr = self.parent_ptr.load(Ordering::SeqCst) as *const u8;
 

--- a/deucalion/src/hook/mod.rs
+++ b/deucalion/src/hook/mod.rs
@@ -61,7 +61,12 @@ impl State {
 
         let wg = waitgroup::WaitGroup::new();
         let hs = State {
-            recv_hook: recv::Hook::new(broadcast_tx.clone(), deobf_queue_tx, wg.clone())?,
+            recv_hook: recv::Hook::new(
+                broadcast_tx.clone(),
+                deobf_queue_tx,
+                deobf_queue_rx.clone(),
+                wg.clone(),
+            )?,
             send_hook: send::Hook::new(broadcast_tx.clone(), wg.clone())?,
             send_lobby_hook: send_lobby::Hook::new(broadcast_tx.clone(), wg.clone())?,
             create_target_hook: create_target::Hook::new(broadcast_tx, deobf_queue_rx, wg.clone())?,

--- a/deucalion/src/hook/packet.rs
+++ b/deucalion/src/hook/packet.rs
@@ -40,7 +40,7 @@ binary_layout!(ipc_header, LittleEndian, {
 
 /// Set the highest bit in padding after the ipc_header opcode to indicate
 /// that Deucalion has marked this IPC packet for later deobfuscation.
-const DEUCALION_DEFER_IPC: u16 = 0x8000;
+pub(super) const DEUCALION_DEFER_IPC: u16 = 0x8000;
 
 binary_layout!(ipc_packet, LittleEndian, {
   header: ipc_header::NestedView,

--- a/deucalion/src/hook/recv.rs
+++ b/deucalion/src/hook/recv.rs
@@ -46,8 +46,7 @@ impl Hook {
     }
 
     pub fn set_create_target_hook_enabled(&self, enabled: bool) {
-        self.create_target_hook_enabled
-            .store(enabled, Ordering::SeqCst);
+        self.create_target_hook_enabled.store(enabled, Ordering::SeqCst);
     }
 
     pub fn setup(&self, rvas: Vec<usize>) -> Result<()> {
@@ -99,7 +98,7 @@ impl Hook {
         };
         let ret = hook.call(a1, a2, a3, a4, a5);
 
-        let ptr_frame: *const u8 = *(a1.add(16) as *const usize) as *const u8;
+        let ptr_frame = *(a1.add(16) as *const usize) as *mut u8;
         let offset: u32 = *(a1.add(28) as *const u32);
         if offset != 0 {
             return ret;

--- a/deucalion/src/hook/send.rs
+++ b/deucalion/src/hook/send.rs
@@ -61,7 +61,7 @@ impl Hook {
     unsafe fn compress_packet(&self, channel: Channel, a1: *const u8, a2: usize) -> usize {
         let _guard = self.wg.add();
 
-        let ptr_frame: *const u8 = *(a1.add(32) as *const usize) as *const u8;
+        let ptr_frame = *(a1.add(32) as *const usize) as *mut u8;
 
         match packet::extract_packets_from_frame(ptr_frame, false) {
             Ok(packets) => {

--- a/deucalion/src/hook/send_lobby.rs
+++ b/deucalion/src/hook/send_lobby.rs
@@ -53,7 +53,7 @@ impl Hook {
     unsafe fn send_lobby_packet(&self, a1: *const u8) -> usize {
         let _guard = self.wg.add();
 
-        let ptr_frame: *const u8 = *(a1.add(32) as *const usize) as *const u8;
+        let ptr_frame = *(a1.add(32) as *const usize) as *mut u8;
 
         match packet::extract_packets_from_frame(ptr_frame, false) {
             Ok(packets) => {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@ style_edition = "2024"
 imports_granularity = "Crate"
 group_imports = "StdExternalCrate"
 struct_lit_width = 60
+chain_width = 80


### PR DESCRIPTION
## Glossary
**Packet queue:** A Deucalion-internal queue used to track which packets need deobfuscation.
**Packet dispatch:** The main handler the game uses to process packets, and is intercepted right after deobfuscation.

There are three scenarios that are tested for:

## Scenario 1
When the packet queue has packets: `A B C D`
and the packet dispatch receives: `B C D`

This is already handled by discarding A from the packet queue and continuing to match what was received in the dispatch to packet B.

## Scenario 2
When the packet queue has packets `B C D`
and the packet dispatch receives `A B C D`

This will be handled by a special bit toggled in the header of the IPC packet. If the packet dispatcher does not see this bit on the packet, then this packet is ignored and the data will not be sent. In this case, `A` will be ignored.

## Scenario 3
When the packet queue has packets `A B C`
and the packet dispatch has no more packets left to process (when the client is getting ready to add more data to the packet queue).

This is handled by completely clearing the packet queue before adding any more new packets to the packet queue.