### PR TITLE
Remove panic unwinding and optimize build size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,12 @@ jobs:
         toolchain: nightly
         override: true
         components: rustfmt, clippy
+    # For some reason, building deucalion inside its own directory yields
+    # a smaller binary
     - name: Build
-      run: cargo build --release
+      run: |
+        cargo build --release
+        cd deucalion
+        cargo build --release
     - name: Build bcryptprimitives.rs shim
       run: rustc shims/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir target/release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,12 @@ jobs:
     - name: List Keys
       run: gpg -K
 
+    # For some reason, building deucalion inside its own directory yields
+    # a smaller binary
     - name: Build
       run: |
+        cargo build --release
+        cd deucalion
         cargo build --release
 
     - name: Build bcryptprimitives.rs shim

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 resolver = "2"
 
 members = ["deucalion", "deucalion-extras", "deucalion-client"]
+
+[profile.release]
+panic = "abort"

--- a/deucalion-client/src/subscriber.rs
+++ b/deucalion-client/src/subscriber.rs
@@ -189,9 +189,7 @@ impl Subscriber {
             .map_err(|_| format_err!("cannot run subscriber more than once"))?;
 
         let subscriber = Retry::spawn(
-            ExponentialBackoff::from_millis(10)
-                .max_delay(Duration::from_secs(1))
-                .take(8),
+            ExponentialBackoff::from_millis(10).max_delay(Duration::from_secs(1)).take(8),
             || Endpoint::connect(pipe_name),
         )
         .await?;
@@ -201,10 +199,7 @@ impl Subscriber {
         let mut frames = Framed::new(subscriber, codec);
 
         // Handle the SERVER_HELLO message
-        let hello_message = frames
-            .next()
-            .await
-            .ok_or(format_err!("Couldn't get next frame"))??;
+        let hello_message = frames.next().await.ok_or(format_err!("Couldn't get next frame"))??;
         if hello_message.ctx != HELLO_CHANNEL {
             return Err(format_err!("First message wasn't a server hello?"));
         }

--- a/deucalion/src/hook/mod.rs
+++ b/deucalion/src/hook/mod.rs
@@ -81,7 +81,7 @@ impl State {
         let sig: &[pattern::Atom] = &pat;
         let ffxiv_file_path = get_ffxiv_filepath()?;
 
-        let image_map = ImageMap::open(&ffxiv_file_path).unwrap();
+        let image_map = ImageMap::open(&ffxiv_file_path)?;
         let pe_image = PeView::from_bytes(image_map.as_ref())?;
 
         let sig_name = match hook_type {

--- a/deucalion/src/lib.rs
+++ b/deucalion/src/lib.rs
@@ -155,9 +155,7 @@ fn pause() {
 }
 
 fn logging_setup() -> Result<()> {
-    let secs_since_epoch = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)?
-        .as_secs();
+    let secs_since_epoch = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH)?.as_secs();
 
     let mut log_path = PathBuf::new();
     log_path.push(dirs::data_dir().context("Data dir not found")?);

--- a/deucalion/src/lib.rs
+++ b/deucalion/src/lib.rs
@@ -189,14 +189,8 @@ unsafe extern "system" fn main(dll_base_addr: LPVOID) -> u32 {
         println!("Error initializing logger: {e}");
     }
 
-    let result = std::panic::catch_unwind(|| {
-        if let Err(e) = main_with_result() {
-            error!("Encountered fatal error: {e}");
-            pause();
-        }
-    });
-    if let Err(cause) = result {
-        error!("Panic happened: {cause:?}");
+    if let Err(e) = main_with_result() {
+        error!("Encountered fatal error: {e}");
         pause();
     }
     if let Err(e) = drop_ref_count_to_one(dll_base_addr as HMODULE) {

--- a/deucalion/src/namedpipe.rs
+++ b/deucalion/src/namedpipe.rs
@@ -101,11 +101,7 @@ impl Endpoint {
         // so we keep trying or sleeping for a bit, until we hit a timeout
         let attempt_start = Instant::now();
         let client = loop {
-            match named_pipe::ClientOptions::new()
-                .read(true)
-                .write(true)
-                .open(path)
-            {
+            match named_pipe::ClientOptions::new().read(true).write(true).open(path) {
                 Ok(client) => break client,
                 Err(e) if e.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
                     if attempt_start.elapsed() < PIPE_AVAILABILITY_TIMEOUT {

--- a/deucalion/src/server.rs
+++ b/deucalion/src/server.rs
@@ -102,10 +102,7 @@ fn validate_nickname(nickname: &str) -> Result<()> {
     if nickname.len() > 30 {
         return Err(format_err!("Nickname exceeds 30 chars: {nickname:?}"));
     }
-    if !nickname
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '_')
-    {
+    if !nickname.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
         return Err(format_err!(
             "Nickname contains invalid characters: {nickname:?}"
         ));
@@ -400,10 +397,7 @@ impl Server {
 
         info!("New subscriber connected: {nickname}");
 
-        match self
-            .subscriber_msg_loop(&mut subscriber, &mut nickname, payload_handler)
-            .await
-        {
+        match self.subscriber_msg_loop(&mut subscriber, &mut nickname, payload_handler).await {
             Ok(server_exit) => {
                 if server_exit {
                     return Ok(());
@@ -744,10 +738,7 @@ mod tests {
             handle_server_hello(&mut frames).await;
 
             for (nickname, expected_resp) in testcases {
-                frames
-                    .send(dbg_payload(HELLO_CHANNEL, nickname))
-                    .await
-                    .unwrap();
+                frames.send(dbg_payload(HELLO_CHANNEL, nickname)).await.unwrap();
 
                 let message = frames.next().await.unwrap();
                 if let Ok(payload) = message {


### PR DESCRIPTION
For the purpose of code cleanup and optimiziing file sizes, we remove the panic unwinding logic.

There doesn't remain any spot in the code that will propagate a rust panic. Any panics that happen in Tokio are already propagated as errors.
Any sort of invalid state that happens in the hooks are either logically unreachable code (validated in test and in runtime), or are in unsafe code.

In the case that an error happens in unsafe code, it should for the most part be gracefully handled in logging. In serious memory access violations, the program will crash without invoking a Rust panic anyway.