### PR TITLE
Preserve rsi for downstream users of create_target

### DIFF
--- a/deucalion/Cargo.toml
+++ b/deucalion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deucalion"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["ff14wed"]
 edition = "2024"
 build = "build.rs"


### PR DESCRIPTION
Fixes #41 

Prevent crashes when Deucalion is injected after another hook has previously hooked CreateTarget