### PR TITLE
Update signatures for patch 7.3

### DIFF
--- a/.github/workflows/deobf-canary.yml
+++ b/.github/workflows/deobf-canary.yml
@@ -27,9 +27,9 @@ jobs:
     - name: Test
       shell: bash
       run: |
-        if grep "# Ensure rsi" "target/release/deps/deucalion.s" -B 20 \
+        if grep "# Ensure r12" "target/release/deps/deucalion.s" -B 20 \
          | grep ".seh_endprologue" -A 10 \
-         | grep -q "movq.*, %rsi$"; then
-          echo "Something found using rsi as a destination register"
+         | grep -q "movq.*, %r12$"; then
+          echo "Something found using r12 as a destination register"
           exit 1
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
     - name: Install latest nightly

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ The following is the compatibility matrix for Deucalion:
 | ------------- | ----------------- |
 | 6.x           | 0.9.x             |
 | 7.0-7.1x      | 1.1.x             |
-| 7.2           | 1.2.x             |
+| 7.2x          | 1.2.x             |
+| 7.3x          | 1.3.x             |
 
 
 ## Features

--- a/deucalion-client/Cargo.toml
+++ b/deucalion-client/Cargo.toml
@@ -12,14 +12,18 @@ readme = "README.md"
 keywords = ["ffxiv", "windows", "dll-injection", "dll"]
 
 [dependencies]
-dll-syringe = { git = "https://github.com/fry/dll-syringe", rev = "0a8b18e" }
+dll-syringe = "0.17"
 deucalion = { path = "../deucalion" }
 tokio = { version = "1.44.1", features = ["io-util", "sync", "rt"] }
 tokio-util = { version = "0.7.14", features = ["codec", "compat"] }
 tokio-retry = "0.3"
 futures = "0.3"
 sysinfo = "0.34"
-winapi = { version = "0.3", features = ["aclapi", "processthreadsapi"] }
+winapi = { version = "0.3", features = [
+    "aclapi",
+    "processthreadsapi",
+    "securitybaseapi",
+] }
 anyhow = "1.0"
 log = "0.4"
 simplelog = "0.12"

--- a/deucalion-client/src/process.rs
+++ b/deucalion-client/src/process.rs
@@ -1,10 +1,4 @@
-use std::{
-    io,
-    mem::MaybeUninit,
-    os::windows::prelude::{AsRawHandle, FromRawHandle, OwnedHandle},
-    path::Path,
-    ptr,
-};
+use std::{io, mem::MaybeUninit, path::Path, ptr};
 
 use anyhow::{Result, format_err};
 use dll_syringe::{
@@ -129,13 +123,11 @@ pub fn copy_current_process_dacl_to_target(target_pid: usize) -> Result<()> {
         return Err(io::Error::last_os_error().into());
     }
 
-    let owned_handle = unsafe { OwnedHandle::from_raw_handle(handle) };
-
     debug!("Setting the security info for the target process");
 
     let ret = unsafe {
         SetSecurityInfo(
-            owned_handle.as_raw_handle(),
+            handle,
             SE_KERNEL_OBJECT,
             DACL_SECURITY_INFORMATION | UNPROTECTED_DACL_SECURITY_INFORMATION,
             ptr::null_mut(),

--- a/deucalion-extras/README.md
+++ b/deucalion-extras/README.md
@@ -13,6 +13,15 @@ Example usage:
 cargo run --bin find_sig_matches "C:\path\to\file.exe" "E8 $ { ' } ? ? ? ?"
 ```
 
+## validate_sigs
+
+Validates that the signatures used in Deucalion work for the target exe.
+
+Example usage:
+```bash
+cargo run --bin validate_sigs "C:\path\to\file.exe"
+```
+
 ## signal_exit
 
 Given a process ID, signals Deucalion to exit if it is running in the target

--- a/deucalion-extras/src/bin/validate_sigs.rs
+++ b/deucalion-extras/src/bin/validate_sigs.rs
@@ -1,0 +1,47 @@
+use std::{env, time::Instant};
+
+use anyhow::{Context, Result, format_err};
+use deucalion::{CREATE_TARGET_SIG, RECV_SIG, SEND_LOBBY_SIG, SEND_SIG, procloader};
+use log::info;
+use pelite::{ImageMap, pattern, pe64::PeView};
+use simplelog::{LevelFilter, SimpleLogger};
+
+fn main() {
+    SimpleLogger::init(LevelFilter::Debug, simplelog::Config::default()).unwrap();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        panic!("Missing argument: exe path. Usage: validate_sigs <path_to_ffxiv_exe>");
+    }
+
+    let target_exe_path = &args[1];
+    let image_map = ImageMap::open(target_exe_path).unwrap();
+    for sig in [RECV_SIG, SEND_SIG, SEND_LOBBY_SIG, CREATE_TARGET_SIG] {
+        info!("===== Searching for sig {sig} in file {target_exe_path} =====");
+        let addrs = scan_sigs(image_map.as_ref(), sig).unwrap();
+        if addrs.is_empty() {
+            panic!("No matches found for signature {sig} in file {target_exe_path}");
+        }
+        info!("Found addresses:");
+        for addr in addrs {
+            info!("{addr:x}");
+        }
+    }
+}
+
+fn scan_sigs(image: &[u8], sig_str: &str) -> Result<Vec<usize>> {
+    let start = Instant::now();
+    let file = PeView::from_bytes(image)?;
+    info!("File load took {:?}", start.elapsed());
+
+    let start = Instant::now();
+    let pat = pattern::parse(sig_str).context(format!("Invalid signature: \"{sig_str}\""))?;
+    let sig: &[pattern::Atom] = &pat;
+
+    let rvas = procloader::find_pattern_matches("", sig, file, true)
+        .map_err(|e| format_err!("{}: {}", e, sig_str))?;
+
+    info!("Pattern search took {:?}", start.elapsed());
+
+    Ok(rvas)
+}

--- a/deucalion/src/lib.rs
+++ b/deucalion/src/lib.rs
@@ -33,12 +33,12 @@ const COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
 const COMMIT_DIRTY: &str = env!("VERGEN_GIT_DIRTY");
 
 const RECV_SIG: &str = "E8 $ { ' } 4C 8B 4F 10 8B 47 1C 45";
-const SEND_SIG: &str = "40 57 41 56 48 83 EC 38 48 8B F9 4C 8B F2";
+const SEND_SIG: &str = "40 53 56 48 83 EC 38 48 8B D9 48 8B F2 8B";
 const SEND_LOBBY_SIG: &str = "40 53 48 83 EC 20 44 8B 41 28";
 /// Overriding with a custom signature for create_target is not supported. If
 /// this has changed, it is likely that the hook is broken in a way that just
 /// a signature change won't fix.
-const CREATE_TARGET_SIG: &str = "E8 $ { ' } 41 83 C7 ? 41 81 FF";
+const CREATE_TARGET_SIG: &str = "E8 $ { ' } 41 83 C5 ? 49 8B FC";
 
 fn handle_payload(payload: rpc::Payload, hs: Arc<hook::State>) -> Result<()> {
     let hook_type = match payload.op {

--- a/deucalion/src/lib.rs
+++ b/deucalion/src/lib.rs
@@ -32,13 +32,13 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 const COMMIT_SHA: &str = env!("VERGEN_GIT_SHA");
 const COMMIT_DIRTY: &str = env!("VERGEN_GIT_DIRTY");
 
-const RECV_SIG: &str = "E8 $ { ' } 4C 8B 4F 10 8B 47 1C 45";
-const SEND_SIG: &str = "40 53 56 48 83 EC 38 48 8B D9 48 8B F2 8B";
-const SEND_LOBBY_SIG: &str = "40 53 48 83 EC 20 44 8B 41 28";
+pub const RECV_SIG: &str = "E8 $ { ' } 4C 8B 4F 10 8B 47 1C 45";
+pub const SEND_SIG: &str = "40 53 56 48 83 EC 38 48 8B D9 48 8B F2 8B";
+pub const SEND_LOBBY_SIG: &str = "40 53 48 83 EC 20 44 8B 41 28";
 /// Overriding with a custom signature for create_target is not supported. If
 /// this has changed, it is likely that the hook is broken in a way that just
 /// a signature change won't fix.
-const CREATE_TARGET_SIG: &str = "E8 $ { ' } 41 83 C5 ? 49 8B FC";
+pub const CREATE_TARGET_SIG: &str = "E8 $ { ' } 41 83 C5 ? 49 8B FC";
 
 fn handle_payload(payload: rpc::Payload, hs: Arc<hook::State>) -> Result<()> {
     let hook_type = match payload.op {


### PR DESCRIPTION
Routine signature update for new patch version.

Due to an updated signature for CreateTarget, older versions of Deucalion will not be compatible with the current version of the game.