### PR TITLE
Remove code signing from GH release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,17 +40,6 @@ jobs:
     - name: Build bcryptprimitives.rs shim
       run: rustc shims/bcryptprimitives.rs -Copt-level=3 -Clto=fat --out-dir target/release
 
-    - name: Code Sign
-      uses: dlemstra/code-sign-action@v1
-      with:
-        certificate: '${{ secrets.CODE_SIGN_CERTIFICATE }}'
-        password: '${{ secrets.CODE_SIGN_PASSWORD }}'
-        recursive: false
-        files: |
-          target/release/deucalion.dll
-          target/release/deucalion_client.exe
-          target/release/bcryptprimitives.dll
-
     - name: Deucalion SHA256Sum and GPG Sign
       run: |
         sha256sum target/release/deucalion.dll > deucalion.sha256sum

--- a/deucalion/src/lib.rs
+++ b/deucalion/src/lib.rs
@@ -184,8 +184,8 @@ fn logging_setup() -> Result<()> {
 }
 
 unsafe extern "system" fn main(dll_base_addr: LPVOID) -> u32 {
+    #[cfg(debug_assertions)]
     unsafe {
-        #[cfg(debug_assertions)]
         consoleapi::AllocConsole();
     }
 


### PR DESCRIPTION
Just use GPG and sha256 to verify authenticity.

Code signing has proven to be pretty useless since it was a self-signed certificate anyways.